### PR TITLE
fixed resizing of 'whats new' and 'keywords'

### DIFF
--- a/Connecter/RMAppDataWindowController.xib
+++ b/Connecter/RMAppDataWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5056" systemVersion="14A329f" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment defaultVersion="1080" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5053"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5056"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="RMAppDataWindowController">
@@ -57,7 +57,7 @@
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="wrQ-hT-udn">
                         <rect key="frame" x="211" y="374" width="80" height="18"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Keywords:" id="1Dm-Zd-SQO">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -66,7 +66,7 @@
                     </textField>
                     <tokenField verticalHuggingPriority="750" id="CdH-p6-a6N">
                         <rect key="frame" x="299" y="352" width="452" height="40"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                         <tokenFieldCell key="cell" selectable="YES" editable="YES" borderStyle="bezel" alignment="left" placeholderString="Keywords" drawsBackground="YES" allowsEditingTextAttributes="YES" id="gvx-rh-Lhd">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -83,7 +83,7 @@
                     </tokenField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="sUk-tz-j37">
                         <rect key="frame" x="211" y="456" width="80" height="18"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="What's new:" id="2WB-5r-aIU">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -92,19 +92,19 @@
                     </textField>
                     <scrollView borderType="groove" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="WP1-cn-B94">
                         <rect key="frame" x="299" y="400" width="452" height="74"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                         <clipView key="contentView" id="3fo-DR-bcj">
-                            <rect key="frame" x="2" y="2" width="448" height="70"/>
+                            <rect key="frame" x="2" y="2" width="433" height="70"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textView importsGraphics="NO" richText="NO" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" spellingCorrection="YES" id="TzS-aS-4PR">
-                                    <rect key="frame" x="0.0" y="0.0" width="448" height="70"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="433" height="70"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="448" height="70"/>
+                                    <size key="minSize" width="433" height="70"/>
                                     <size key="maxSize" width="538" height="10000000"/>
                                     <color key="insertionPointColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="448" height="70"/>
+                                    <size key="minSize" width="433" height="70"/>
                                     <size key="maxSize" width="538" height="10000000"/>
                                     <connections>
                                         <binding destination="wkQ-lw-xLY" name="value" keyPath="selection.whatsNew" id="9ZQ-vN-dfh"/>
@@ -118,7 +118,7 @@
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="oKw-xs-sk9">
-                            <rect key="frame" x="434" y="2" width="16" height="70"/>
+                            <rect key="frame" x="435" y="2" width="15" height="70"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                     </scrollView>
@@ -135,17 +135,17 @@
                         <rect key="frame" x="298" y="482" width="452" height="147"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="x4k-ez-Yu0">
-                            <rect key="frame" x="2" y="2" width="448" height="143"/>
+                            <rect key="frame" x="2" y="2" width="433" height="143"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textView importsGraphics="NO" richText="NO" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" spellingCorrection="YES" id="L2T-Md-bL4">
-                                    <rect key="frame" x="0.0" y="0.0" width="448" height="143"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="433" height="143"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="448" height="143"/>
+                                    <size key="minSize" width="433" height="143"/>
                                     <size key="maxSize" width="538" height="10000000"/>
                                     <color key="insertionPointColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                    <size key="minSize" width="448" height="143"/>
+                                    <size key="minSize" width="433" height="143"/>
                                     <size key="maxSize" width="538" height="10000000"/>
                                     <connections>
                                         <binding destination="wkQ-lw-xLY" name="value" keyPath="selection.appDescription" id="97c-jy-h0a"/>
@@ -159,11 +159,11 @@
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Y3x-Wf-8Nb">
-                            <rect key="frame" x="434" y="2" width="16" height="143"/>
+                            <rect key="frame" x="435" y="2" width="15" height="143"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                     </scrollView>
-                    <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="qeZ-ai-KNe">
+                    <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="qeZ-ai-KNe">
                         <rect key="frame" x="200" y="337" width="560" height="5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                         <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
@@ -286,14 +286,14 @@
                         <rect key="frame" x="230" y="20" width="500" height="150"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     </customView>
-                    <scrollView autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="ONT-yA-sE1">
+                    <scrollView autohidesScrollers="YES" horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="ONT-yA-sE1">
                         <rect key="frame" x="-1" y="-1" width="193" height="677"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
-                        <clipView key="contentView" id="poB-A6-agN">
+                        <clipView key="contentView" drawsBackground="NO" id="poB-A6-agN">
                             <rect key="frame" x="1" y="1" width="191" height="675"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" rowSizeStyle="systemDefault" viewBased="YES" indentationPerLevel="16" outlineTableColumn="19B-1p-TeZ" id="ccT-qq-iMs" customClass="RMOutlineView">
+                                <outlineView appearanceType="userCustom" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="22" rowSizeStyle="systemDefault" viewBased="YES" indentationPerLevel="16" outlineTableColumn="19B-1p-TeZ" id="ccT-qq-iMs" customClass="RMOutlineView">
                                     <rect key="frame" x="0.0" y="0.0" width="191" height="675"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -335,7 +335,7 @@
                                     </tableColumns>
                                 </outlineView>
                             </subviews>
-                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            <nil key="backgroundColor"/>
                         </clipView>
                         <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="Cly-C3-JbY">
                             <rect key="frame" x="1" y="119" width="238" height="15"/>


### PR DESCRIPTION
anchored the 'What's new' and 'Keywords' fields to the bottom so they don't disappear when the view is resized.
